### PR TITLE
Install dig command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -364,6 +364,7 @@ repositories_setup(){
                 add-apt-repository -y ppa:nginx/development
             fi
 	        apt -y install tuned
+		apt-get install dnsutils -y 
             tuned-adm profile latency-performance   
         elif [ "$lsb_dist" =  "debian" ]; then
             apt-get -y install ca-certificates apt-transport-https


### PR DESCRIPTION
I've noticed on a couple of machines that dig is not installed by default anymore causing the FQDN check to fail.