### PR TITLE
Fix mariadb binding on ubuntu servers.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -531,7 +531,12 @@ install_pterodactyl() {
     mysql -u root -e "$SQL"
 
     output "Binding MariaDB/MySQL to 0.0.0.0."
-	if [ -f /etc/mysql/my.cnf ] ; then
+        if [ -f /etc/mysql/mariadb.conf.d/50-server.cnf ] ; then
+        	sed -i -- 's/bind-address/# bind-address/g' /etc/mysql/mariadb.conf.d/50-server.cnf
+		sed -i '/\[mysqld\]/a bind-address = 0.0.0.0' /etc/mysql/mariadb.conf.d/50-server.cnf
+		output 'Restarting MySQL process...'
+		service mysql restart
+	elif [ -f /etc/mysql/my.cnf ] ; then
         	sed -i -- 's/bind-address/# bind-address/g' /etc/mysql/my.cnf
 		sed -i '/\[mysqld\]/a bind-address = 0.0.0.0' /etc/mysql/my.cnf
 		output 'Restarting MySQL process...'
@@ -544,11 +549,6 @@ install_pterodactyl() {
     	elif [ -f /etc/mysql/my.conf.d/mysqld.cnf ] ; then
         	sed -i -- 's/bind-address/# bind-address/g' /etc/mysql/my.conf.d/mysqld.cnf
 		sed -i '/\[mysqld\]/a bind-address = 0.0.0.0' /etc/mysql/my.conf.d/mysqld.cnf
-		output 'Restarting MySQL process...'
-		service mysql restart
-    	elif [ -f /etc/mysql/mariadb.conf.d/50-server.cnf ] ; then
-        	sed -i -- 's/bind-address/# bind-address/g' /etc/mysql/mariadb.conf.d/50-server.cnf
-		sed -i '/\[mysqld\]/a bind-address = 0.0.0.0' /etc/mysql/mariadb.conf.d/50-server.cnf
 		output 'Restarting MySQL process...'
 		service mysql restart
 	else 


### PR DESCRIPTION
with the newer ubuntu versions the bind address is in 5-server.cnf instead of my.cnf while my.cnf still exists. This if-else branch never accesses the code to fix 50-server.cnf if my.cnf still exists so moving the 50-server.cnf to the top fixes the issue.

tested on multiple 16.04 and 18.04 vpsses.